### PR TITLE
修复子应用默认证书密码解密错误的问题

### DIFF
--- a/src/org/zywx/wbpalmstar/plugin/uexmultiHttp/EUExXmlHttpMgr.java
+++ b/src/org/zywx/wbpalmstar/plugin/uexmultiHttp/EUExXmlHttpMgr.java
@@ -199,6 +199,7 @@ public class EUExXmlHttpMgr extends EUExBase {
 			WWidgetData wd = mBrwView.getCurrentWidget();
 			if ("default".equalsIgnoreCase(cPath)) {
 				cPath = "file:///android_asset/widget/wgtRes/clientCertificate.p12";
+				wd = mBrwView.getRootWidget();
 				String appId = wd.m_appId;
 				String psw = EUExUtil.getCertificatePsw(mContext, appId);
 				cPassWord = psw;

--- a/uexXmlHttpMgr/info.xml
+++ b/uexXmlHttpMgr/info.xml
@@ -1,7 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <uexplugins>
-	<plugin uexName="uexXmlHttpMgr" version="3.0.16" build = "16">
-		<info>16:修复证书路径解析错误问题</info>
+	<plugin uexName="uexXmlHttpMgr" version="3.0.17" build = "17">
+		<info>17:修复子应用默认证书密码解密错误的问题</info>
+		<build>16:修复证书路径解析错误问题</build>
 		<build>15:onData回调函数参数修改</build>
 		<build>14:处理网络超时，并回调给网页端</build>
 		<build>13:添加getCookie接口</build>


### PR DESCRIPTION
Default证书密码需要由主应用appId解密，否则解密出错，已经修正。
